### PR TITLE
remove close operation after launch uploading

### DIFF
--- a/easy_allure/allurectl.py
+++ b/easy_allure/allurectl.py
@@ -48,7 +48,7 @@ def download_allurectl(dest_dir: str, platform_name: str = None) -> None:
     file_url = 'https://github.com/allure-framework/allurectl/'\
                'releases/download/{}/{}'\
                .format(ALLURECTL_VERSION, executable_name)
-    LOGGER.info('Downloading allurectl from {}'.format(file_url))
+    LOGGER.debug('Downloading allurectl from {}'.format(file_url))
     download_file(file_url, dest_dir, executable_name)
 
 

--- a/easy_allure/main.py
+++ b/easy_allure/main.py
@@ -57,9 +57,6 @@ def main():
     parser.add_argument('reports_path')
     parser.add_argument('-l', '--launch-name', dest='launch_name',
                         default='default_launch_name')
-    parser.add_argument('--close', action='store_true',
-                        dest='close_launch',
-                        help='close launch right after upload')
 
     parsed_args = parser.parse_args()
     if parsed_args.verbose:

--- a/easy_allure/main.py
+++ b/easy_allure/main.py
@@ -52,10 +52,14 @@ def main():
 
     actions = get_available_actions()
     parser = get_default_parser(prog='easy_allure')
+
     parser.add_argument('action', choices=actions.keys())
     parser.add_argument('reports_path')
     parser.add_argument('-l', '--launch-name', dest='launch_name',
                         default='default_launch_name')
+    parser.add_argument('--close', action='store_true',
+                        dest='close_launch',
+                        help='close launch right after upload')
 
     parsed_args = parser.parse_args()
     if parsed_args.verbose:

--- a/easy_allure/testops.py
+++ b/easy_allure/testops.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import time
 from typing import Dict
 
 from .allurectl import install_allurectl
@@ -51,10 +52,12 @@ class AllureTestops():
             raise ScriptException(errMessage)
 
 
-def send_to_testops(testops_obj, parsed_args: argparse.Namespace) -> int:
+def send_to_testops(testops_obj, parsed_args: argparse.Namespace, pause_time: int = 60) -> int:
     launch_id = testops_obj.create_launch(parsed_args.launch_name)
     testops_obj.upload_launch(parsed_args.reports_path, launch_id)
-    testops_obj.close_launch(launch_id)
+    if parsed_args.close_launch:
+        time.sleep(pause_time)
+        testops_obj.close_launch(launch_id)
 
     allure_endpoint = os.environ.get('ALLURE_ENDPOINT')
     LOGGER.info('Test run was successfully pushed to {}/launch/{}'

--- a/easy_allure/testops.py
+++ b/easy_allure/testops.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import time
 from typing import Dict
 
 from .allurectl import install_allurectl
@@ -52,12 +51,9 @@ class AllureTestops():
             raise ScriptException(errMessage)
 
 
-def send_to_testops(testops_obj, parsed_args: argparse.Namespace, pause_time: int = 60) -> int:
+def send_to_testops(testops_obj, parsed_args: argparse.Namespace) -> int:
     launch_id = testops_obj.create_launch(parsed_args.launch_name)
     testops_obj.upload_launch(parsed_args.reports_path, launch_id)
-    if parsed_args.close_launch:
-        time.sleep(pause_time)
-        testops_obj.close_launch(launch_id)
 
     allure_endpoint = os.environ.get('ALLURE_ENDPOINT')
     LOGGER.info('Test run was successfully pushed to {}/launch/{}'


### PR DESCRIPTION
Due to the fact that the run closes immediately after the results are uploaded, some test cases do not have time to be uploaded into TestOps.